### PR TITLE
Replace hex-notation with binary in `CollisionLayer` docs

### DIFF
--- a/src/physics_components/mod.rs
+++ b/src/physics_components/mod.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
     The mask field sets what collision layers the object lays in,
     
-    The layer field sets what collision layesr the boject will check for in collision,
+    The layer field sets what collision layers the object will check for in collision,
     
     Both fields are represented as the individual bits in a `u8`(so there are 8 layers).
 
@@ -25,21 +25,21 @@ use serde::{Deserialize, Serialize};
     ## Adding/Removing Layers(applies for masks as well)
 
     The easiest way to handle layers is to flip them using he `^`(xor - exclusive or) operator,
-    we can flip a specific layer(for example, the forth layer) by doing `layer = layer ^ 0x0000_1000`.
+    we can flip a specific layer(for example, the fourth layer) by doing `layer = layer ^ 0b0000_1000`.
 
     Flipping a layer will add it if it wasn't added already, and remove it if it was added before.
 
-    Adding a layer(for example, the third layer) is as simple as doing `layer = layer | 0x0000_0100...`.
+    Adding a layer(for example, the third layer) is as simple as doing `layer = layer | 0b0000_0100...`.
 
     Removing a specific layer(without flipping it) is rather a problem,
     we will need to use the `&` operator, but for each bit we didnt write,
     the compiler will assume it as `0`,
     but since we are working with `u8` we can simply write all the bits,
-    so to remove a layer(for example, the second layer) we will do `layer = layer & 0x1111_1101`.
+    so to remove a layer(for example, the second layer) we will do `layer = layer & 0b1111_1101`.
 
     We can also add/remove/flip multiple layers at a time.
 
-    For example, if we want to add layers 2 and 3 in one go, we can do `layer = layer | 0x000_0110`
+    For example, if we want to add layers 2 and 3 in one go, we can do `layer = layer | 0b0000_0110`
 */
 #[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize, Component)]
 pub struct CollisionLayer {


### PR DESCRIPTION
The `CollisionLayer` documentation has examples that uses binary operators, but the example integers are written in hexadecimal notation. This PR replaces each instance of hexadecimal notation (`0x0000_0001`) with binary notation (`0b0000_0001`).

The PR also fixes minor typos on the same page.